### PR TITLE
Bindings (dependency injection), good idea?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change Log
 
+## [Unreleased][unreleased]
+### Added
+- Add `:bindings` option to `defstate` and `start`. See README for details.
+
+
 ## [0.9.4] - 2016-02-11
 ### Changed
-- Memoization (with a cache of 1) has been added to the var dependency graph calculation
+- Memoization (with a cache of 1) has been added to the var dependency graph calculation, for speed.
 
 ### Fixed
 - Stopping `:up-to` an already stopped state now will stop its started dependencies. Same for starting up to an already started state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased][unreleased]
 ### Added
-- Add `:bindings` option to `defstate` and `start`. See README for details.
+- Add optional bindings to `defstate`, and `:bindings` option to `start`. See README for details.
 
 
 ## [0.9.4] - 2016-02-11

--- a/README.md
+++ b/README.md
@@ -269,19 +269,18 @@ one would stop above example, the states `core` and `mid2` will be stopped in pa
 
 It is generally best to define the `defstate`s in application namespaces, not in the more general (library) namespaces. This is because the `:start` and `:stop` expressions are tightly coupled to their environment, including references to other states. This is fine though, as you as the application writer have full control over your states, and resources should be at the periphery of the application anyway.
 
-Yet, in the rare situations where you need a looser coupling between the `:start`/`:stop` expressions and their environment, mount-lite has a unique feature called bindings. When defining a `defstate`, one can optionally supply a `:bindings` vector, next to the `:start` and `:stop` expressions. This vector declares the bindings that can be used by the `:start`/`:stop` expressions, and their defaults. For example:
+Yet, in the rare situations where you need a looser coupling between the `:start`/`:stop` expressions and their environment, mount-lite has a unique feature called bindings. When defining a `defstate`, one can optionally supply a vector, just before the `:start` and `:stop` expressions. This vector declares the bindings that can be used by the `:start`/`:stop` expressions, and their defaults. For example:
 
 ```clj
-(defstate incrementer
-  :start    (fn [n] (+ n i))
-  :stop     (println "stopping incrementer of" i)
-  :bindings [i 10])
+(defstate incrementer [i 10]
+  :start (fn [n] (+ n i))
+  :stop  (println "stopping incrementer of" i))
 ```
 
 When the `incrementer` state is started normally, it will become a function that increments the argument by 10. However, one can start the `incrementer` with different bindings, like so:
 
 ```clj
-(mount/start (bindings #'incrementer {'i 20})
+(mount/start (bindings #'incrementer '[i 20])
 ;=> (#'incrementer)
 
 (incrementer 5)
@@ -294,7 +293,9 @@ When the `incrementer` state is started normally, it will become a function that
 
 As can be seen, the bindings that were used when starting the state are also used when stopping the state.
 
-This bindings feature can be used as a kind of dependency injection or for passing configuration parameters. Yet, at the current time of writing, my opinion is to use this feature sparingly. Substitutions are normally sufficient and using bindings a lot might hint towards a design flaw.
+> NOTE: If you want to inspect what the binding values are when a state has started, consult the var meta key `:mount.lite/current-bindings`.
+
+This bindings feature can be used for passing configuration parameters or even as a kind of dependency injection. Yet, at the current time of writing, my opinion is to use this feature sparingly. Configuration can be read from some configuration state, and substitutions are normally sufficient for mocking. Using bindings a lot, especially for dependency injection, might hint towards a design flaw.
 
 *Whatever your style or situation, enjoy!*
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ When the `incrementer` state is started normally, it will become a function that
 
 As can be seen, the bindings that were used when starting the state are also used when stopping the state.
 
-This bindings feature can be used as a kind of dependency injection or for passing configuration parameters. Yet, at the current time of writing, my opinion is to use this feature sparingly.
+This bindings feature can be used as a kind of dependency injection or for passing configuration parameters. Yet, at the current time of writing, my opinion is to use this feature sparingly. Substitutions are normally sufficient and using bindings a lot might hint towards a design flaw.
 
 *Whatever your style or situation, enjoy!*
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Put this in your dependencies `[functionalbytes/mount-lite "0.9.4"]` and make su
 Also make sure you use Clojure 1.7+, as the library uses transducers and volatiles.
 Read on for a description of the library functions, or go straight to the [API docs](http://aroemers.github.io/mount-lite/index.html).
 
+> NOTE: Clojure 1.8 - with its direct linking - is safe to use as well.
+
 ### Global states, starting and stopping
 
 First, require the `mount.lite` namespace:

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ one would stop above example, the states `core` and `mid2` will be stopped in pa
 
 ### Bindings
 
-It is generally best to define the `defstate`s in application namespaces, not in the more general (library) namespaces. This is because the `:start` and `:stop` expressions are tightly coupled to their surroundings, including references to other states. This is fine though, as you as the application writer have full control over your states, and resources should be at the periphery of the application anyway.
+It is generally best to define the `defstate`s in application namespaces, not in the more general (library) namespaces. This is because the `:start` and `:stop` expressions are tightly coupled to their environment, including references to other states. This is fine though, as you as the application writer have full control over your states, and resources should be at the periphery of the application anyway.
 
-Yet, in the rare situations where you need a looser coupling between the `:start`/`:stop` expressions and their surroundings, mount-lite has a unique feature called bindings. When defining a `defstate`, one can optionally supply a `:bindings` vector, next to the `:start` and `:stop` expressions. This vector declares the bindings that can be used by the `:start`/`:stop` expressions, and their defaults. For example:
+Yet, in the rare situations where you need a looser coupling between the `:start`/`:stop` expressions and their environment, mount-lite has a unique feature called bindings. When defining a `defstate`, one can optionally supply a `:bindings` vector, next to the `:start` and `:stop` expressions. This vector declares the bindings that can be used by the `:start`/`:stop` expressions, and their defaults. For example:
 
 ```clj
 (defstate incrementer
@@ -294,7 +294,7 @@ When the `incrementer` state is started normally, it will become a function that
 
 As can be seen, the bindings that were used when starting the state are also used when stopping the state.
 
-This bindings feature can be used as some kind of dependency injection or for passing configuration parameters. Yet, at the current time of writing, my opinion is to use this feature sparingly.
+This bindings feature can be used as a kind of dependency injection or for passing configuration parameters. Yet, at the current time of writing, my opinion is to use this feature sparingly.
 
 *Whatever your style or situation, enjoy!*
 

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -96,7 +96,8 @@
   (let [bindings (:bindings opts)]
     (reduce-kv (fn [m var state]
                  (assoc m var {:start (fn [] ((:start state) (get bindings var)))
-                               :stop  (fn [] ((:stop state) (get bindings var)))}))
+                               :stop  (when-let [stop-fn (:stop state)]
+                                        (fn [] (stop-fn (get bindings var))))}))
                {} vsm)))
 
 (defn- name-with-attrs [name [arg1 arg2 & argx :as args]]

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -53,7 +53,8 @@
           (catch Throwable t
             (throw (ex-info (str "Error while stopping " var' ":") {:var var' :state state'} t)))))
       (alter-var-root var' (constantly (Unstarted. var')))
-      (alter-meta! var' assoc ::status :stopped))
+      (alter-meta! var' assoc ::status :stopped)
+      (alter-meta! var' dissoc ::current-stop))
     sorted-vars))
 
 (def ^:private all-states

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -68,7 +68,7 @@
   (is (= state-3 "state-1 + state-2 + state-3") "State 1 is back to its original."))
 
 (deftest test-substitute-map
-  (start (substitute #'state-2 {:start (constantly "sub-2")}))
+  (start (substitute #'state-2 {:start (fn [] "sub-2")}))
   (is (= state-3 "sub-2 + state-3") "State 2 is substituted by map.")
   (stop)
   (start)
@@ -133,7 +133,9 @@
 
 (deftest test-bindings
   (let [p (promise)]
-    (start (bindings #'state-2 {'s " + BOUND" 'p p}))
+    (start (bindings #'state-2 ['s " + BOUND" 'p p]))
     (is (= state-2 "state-1 + BOUND") "State 2 has been bound.")
+    (is (= (-> #'state-2 meta :mount.lite/current-bindings (->> (apply hash-map)) (get 'p)) p)
+        "Current bindings is set.")
     (stop)
     (is (realized? p) "State 2 binding also used in stop.")))

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -130,3 +130,10 @@
   (start (only #'state-3))
   (is (= (start (up-to #'state-3)) [#'state-1 #'state-2])
       "Dependencies are started, even though state 1 was already started. State 1 is not started again."))
+
+(deftest test-bindings
+  (let [p (promise)]
+    (start (bindings #'state-2 {'s " + BOUND" 'p p}))
+    (is (= state-2 "state-1 + BOUND") "State 2 has been bound.")
+    (stop)
+    (is (realized? p) "State 2 binding also used in stop.")))

--- a/test/mount/lite_test/test_state_2.clj
+++ b/test/mount/lite_test/test_state_2.clj
@@ -2,4 +2,8 @@
   (:require [mount.lite :refer (defstate)]
             [mount.lite-test.test-state-1 :refer (state-1)]))
 
-(defstate state-2 :start (str state-1 " + state-2"))
+(defstate state-2
+  :start (str state-1 s)
+  :stop (deliver p "delivery!")
+  :bindings [s " + state-2"
+             p (promise)])

--- a/test/mount/lite_test/test_state_2.clj
+++ b/test/mount/lite_test/test_state_2.clj
@@ -2,8 +2,7 @@
   (:require [mount.lite :refer (defstate)]
             [mount.lite-test.test-state-1 :refer (state-1)]))
 
-(defstate state-2
+(defstate state-2 [s " + state-2"
+                   p (promise)]
   :start (str state-1 s)
-  :stop (deliver p "delivery!")
-  :bindings [s " + state-2"
-             p (promise)])
+  :stop (deliver p "delivery!"))


### PR DESCRIPTION
*_From the README:_*

### Bindings

It is generally best to define the `defstate`s in application namespaces, not in the more general (library) namespaces. This is because the `:start` and `:stop` expressions are tightly coupled to their environment, including references to other states. This is fine though, as you as the application writer have full control over your states, and resources should be at the periphery of the application anyway.

Yet, in the rare situations where you need a looser coupling between the `:start`/`:stop` expressions and their environment, mount-lite has a unique feature called bindings. When defining a `defstate`, one can optionally supply a `:bindings` vector, next to the `:start` and `:stop` expressions. This vector declares the bindings that can be used by the `:start`/`:stop` expressions, and their defaults. For example:

```clj
(defstate incrementer
  :start    (fn [n] (+ n i))
  :stop     (println "stopping incrementer of" i)
  :bindings [i 10])
```

When the `incrementer` state is started normally, it will become a function that increments the argument by 10. However, one can start the `incrementer` with different bindings, like so:

```clj
(mount/start (bindings #'incrementer {'i 20})
;=> (#'incrementer)

(incrementer 5)
;=> 25

(stop)
;>> stopping 20 incrementer
;=> (#'incrementer)
```

As can be seen, the bindings that were used when starting the state are also used when stopping the state.

This bindings feature can be used as a kind of dependency injection or for passing configuration parameters. Yet, at the current time of writing, my opinion is to use this feature sparingly. Substitutions are normally sufficient and using bindings a lot might hint towards a design flaw. 

*_My opinion as of the time of this writing:_*

For passing in some configuration values (e.g. command line arguments), I think this is a very nice solution: no need for thread-local dynamic vars (which will break in parallel mode) or other fragile and rigid solutions. Bindings in that sense offer **an easy, cleanly scoped and semantically clear way of passing values to states**, ensuring the same values on stop as when a state was started.

Yet, the number of use cases currently seem very slim. In my opinion it should not be used to pass one state/resource to another state as some form of dependency injection. States can simply refer to those states/resources directly; which is the ease that mount offers. And those referred states can be substituted. Most configuration of states would be by referring to some config state. So, only this initial config state might benefit from the bindings feature. 

So, powerful in theory (as it removes the last "limitation" of mount - tight coupling), but not many use cases in practice? and maybe too powerful leading to "wrong" usage of mount? The tight coupling limitation is a good thing, because states should be in fully controlled application namespaces anyway?

Time will tell. But anyone reading this, know that this feature exists (which was only 12 lines of real code anyway), and **please share your use case or opinion on the matter**.