### PR TITLE
Include var neighbors in with-transitives*

### DIFF
--- a/src/mount/extensions/common_deps.clj
+++ b/src/mount/extensions/common_deps.clj
@@ -8,7 +8,7 @@
   "Given a graph and a node, returns all the transitive nodes."
   [graph node]
   (loop [unexpanded (graph node)
-         expanded #{}]
+         expanded   #{}]
     (if-let [[node & more] (seq unexpanded)]
       (if (contains? expanded node)
         (recur more expanded)
@@ -23,8 +23,9 @@
   (let [var-kw       (utils/var->keyword var)
         dependencies (transitive (:dependencies graphs) var-kw)
         dependents   (transitive (:dependents graphs) var-kw)
-        concatted    (set (concat dependencies dependents))]
-    (binding [mount/*states* (atom (filter (conj concatted var-kw) @mount/*states*))]
+        neighbors    (filter #(= (namespace var-kw) (namespace %)) @mount/*states*)
+        concatted    (set (concat dependencies dependents neighbors))]
+    (binding [mount/*states* (atom (filter concatted @mount/*states*))]
       (f))))
 
 (defmacro with-transitives


### PR DESCRIPTION
The problem was with defstates defined in the same namespace:

```clj
(m/defstate s1 :start {})
(m/defstate s2 :start {})

(require '[mount.extensions.namespace-deps :as mnd])

;; Won't start s1
(mnd/start #'s2)
```

This PR hopefully (works for me) fixes it.
However, I didn't have "stop-down-to" case in mind, so please double check it :)