### PR TITLE
Throw Error when accessing an unstarted state

### DIFF
--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -22,20 +22,17 @@
 
 (defn- throw-started
   [name]
-  (throw (ex-info (format "state %s already started %s" name
-                          (if (.get itl) "in this session" ""))
-                  {:name name})))
+  (throw (Error. (format "state %s already started %s" name
+                          (if (.get itl) "in this session" "")))))
 
 (defn- throw-unstarted
   [name]
-  (throw (ex-info (format "state %s not started %s" name
-                          (if (.get itl) "in this session" ""))
-                  {:name name})))
+  (throw (Error. (format "state %s not started %s" name
+                          (if (.get itl) "in this session" "")))))
 
 (defn- throw-not-found
   [var]
-  (throw (ex-info (format "var %s is not a state" var)
-                  {:var var})))
+  (throw (Error. (format "var %s is not a state" var))))
 
 (defrecord State [start-fn stop-fn name sessions]
   IState

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -47,6 +47,9 @@
                (with-substitutes [#'state-1 (state :start (throw (ex-info "Boom!" {})))]
                  (start)))))
 
+(deftest accessing-unstarted-throws-error
+  (is (thrown? Error @state-1)))
+
 (deftest test-status
   (is (= (status) {#'state-1 :stopped #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
   (start)


### PR DESCRIPTION
Hi Arnout,

I'm quite enjoying mount-lite now :) I'm developing several services based on it, and I've encountered a minor issue.

When I write my unit tests, I sometimes start the application excluding some states that perform side effects (like accessing AWS). When I (erroneously) forget to mock some function that uses those states, the `@` throws an ExceptionInfo "state xxx not started".

However, if that call is wrapped in a `(try ... (catch Exception _))`, this error does not propagate to the top level, hiding the error from the test runner.

I imagine that this could be easily solved by throwing `Error` (which does not inherit `Exception`, but `Throwable`). It also seems the right thing to do, as state configuration problems are always programmer's errors and are not meant to be caught like `ExceptionInfo`.

Here is my humble PR to implement this proposal. Please let me know what you think.

Thanks in advance.