### PR TITLE
Allow :start to be specified with a falsy value

### DIFF
--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -107,7 +107,7 @@
   keyword arguments. A required :start expression, an optional :stop
   expression, and an optional :name for the state."
   [& {:keys [start stop name] :or {name "-anonymous-"} :as fields}]
-  (if start
+  (if (contains? fields :start)
     `(#'map->State (merge ~(dissoc fields :start :stop :name)
                           {:start-fn (fn [] ~start)
                            :stop-fn  (fn [~'this] ~stop)

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -35,6 +35,10 @@
   (start)
   (is (= @state-3 "state-1 + state-2 + state-3") "State 1 is back to its original."))
 
+(deftest test-falsy-start
+  (is (state :start nil))
+  (is (state :start false)))
+
 (deftest test-substitute-map
   (with-substitutes [#'state-2 {:start-fn (fn [] "sub-2")}] (start))
   (is (= @state-3 "sub-2 + state-3") "State 2 is substituted by map.")


### PR DESCRIPTION
Currently, this fails

```clojure
(defstate check?
  :start false)
```

due to the falsy check here https://github.com/aroemers/mount-lite/blob/2.x/src/mount/lite.clj#L110. This simple fix uses a `contains?` check instead.

This is useful when using particular substitutes in say a test environment.