### PR TITLE
Order transitive dependencies

### DIFF
--- a/src/mount/extensions/explicit_deps.clj
+++ b/src/mount/extensions/explicit_deps.clj
@@ -36,7 +36,7 @@
   "Just like the core `start`, except with an `up-to-var`it only
   starts the explicit transitive dependencies of that state."
   ([]
-   (mount/start))
+   (start nil))
   ([up-to-var]
    (common-deps/with-transitives up-to-var (build-graphs)
      (mount/start up-to-var))))
@@ -45,7 +45,7 @@
   "Just like the core `stop`, except with a `down-to-var` it only
   stops the explicit transitive dependents of that state."
   ([]
-   (mount/stop))
+   (stop nil))
   ([down-to-var]
    (mount/with-substitutes []
      (common-deps/with-transitives down-to-var (build-graphs)

--- a/src/mount/extensions/namespace_deps.clj
+++ b/src/mount/extensions/namespace_deps.clj
@@ -65,7 +65,7 @@
   "Just like the core `start`, except with an `up-to-var`, it only
   starts the transitive dependencies of that state."
   ([]
-   (mount/start))
+   (start nil))
   ([up-to-var]
    (common-deps/with-transitives up-to-var (build-graphs)
      (mount/start up-to-var))))
@@ -74,7 +74,7 @@
   "Just like the core `stop`, except with a `down-to-var`, it only
   stops the transitive dependents of that state."
   ([]
-   (mount/stop))
+   (stop nil))
   ([down-to-var]
    (common-deps/with-transitives down-to-var (build-graphs)
      (mount/stop down-to-var))))

--- a/test/mount/extensions/common_deps_test.clj
+++ b/test/mount/extensions/common_deps_test.clj
@@ -44,14 +44,26 @@
 
 (deftest transitives-test
   (testing "ordering active states in dependency order"
-    (is (= [::debug
-            ::env
+    (is (= [::config-a
+            ::overrides-a
             ::config-b
             ::overrides-b
-            ::config-a
-            ::overrides-a
             ::overrides
+            ::env
             ::config
             ::db
+            ::debug
             ::system]
-           (sut/transitives #'system graphs states)))))
+           (sut/transitives #'system graphs states)))
+    (is (= [::config-a
+            ::overrides-a
+            ::config-b
+            ::overrides-b
+            ::overrides
+            ::env
+            ::config
+            ::db
+            ::debug
+            ::system
+            ::registry]
+           (sut/transitives nil graphs states)))))

--- a/test/mount/extensions/common_deps_test.clj
+++ b/test/mount/extensions/common_deps_test.clj
@@ -1,0 +1,57 @@
+(ns mount.extensions.common-deps-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [mount.extensions.common-deps :as sut]))
+
+(def system "system")
+
+(def graphs
+  {:dependencies {::overrides   #{::overrides-a ::overrides-b}
+                  ::config-a    #{}
+                  ::overrides-a #{::config-a}
+                  ::config-b    #{}
+                  ::registry    #{}
+                  ::config      #{::overrides ::env}
+                  ::system      #{::config ::debug ::db}
+                  ::debug       #{}
+                  ::db          #{::config}
+                  ::env         #{}
+                  ::overrides-b #{::config-b}}
+   :dependents   {::overrides   #{::config}
+                  ::config-a    #{::overrides-a}
+                  ::overrides-a #{::overrides}
+                  ::config-b    #{::overrides-b}
+                  ::registry    #{}
+                  ::config      #{::system ::db}
+                  ::system      #{}
+                  ::debug       #{::system}
+                  ::db          #{::system}
+                  ::env         #{::config}
+                  ::overrides-b #{::overrides}}})
+
+(def states
+  [::overrides
+   ::config-a
+   ::overrides-a
+   ::config-b
+   ::registry
+   ::config
+   ::system
+   ::debug
+   ::db
+   ::env
+   ::overrides-b])
+
+(deftest transitives-test
+  (testing "ordering active states in dependency order"
+    (is (= [::debug
+            ::env
+            ::config-b
+            ::overrides-b
+            ::config-a
+            ::overrides-a
+            ::overrides
+            ::config
+            ::db
+            ::system]
+           (sut/transitives #'system graphs states)))))

--- a/test/mount/extensions/explicit_deps_test.clj
+++ b/test/mount/extensions/explicit_deps_test.clj
@@ -1,7 +1,8 @@
 (ns mount.extensions.explicit-deps-test
   (:require [clojure.test :refer (deftest is use-fixtures testing)]
             [mount.extensions.explicit-deps :as deps]
-            [mount.lite :refer (start state status stop with-substitutes)]
+            [mount.lite :as mount :refer (defstate start state status stop with-substitutes)]
+            [mount.utils :as utils]
             [mount.lite-test.test-state-1 :as ts1 :refer (state-1)]
             [mount.lite-test.test-state-2 :as ts2 :refer (state-2)]
             [mount.lite-test.test-state-2-extra :as ts2e :refer (state-2-a state-2-b)]
@@ -11,9 +12,25 @@
 
 (use-fixtures :each (fn [f] (stop) (f) (stop)))
 
+(declare someone)
+
+(defn def-someone
+  []
+  (defstate someone
+    :start "i am someone"
+    :dependencies nil))
+
+(defn undef-someone
+  []
+  (ns-unmap *ns* 'someone)
+  (swap! mount/*states*
+         #(remove %2 %1)
+         #(= % (utils/var->keyword #'someone))))
+
 ;;; Tests.
 
 (def dont-need-anyone (state :start "appeltaart" :dependencies nil))
+(def i-need-someone (state :start (str @someone " yay!") :dependencies [#'someone]))
 
 (deftest build-graphs-test
   (testing "no substitutes used"
@@ -39,6 +56,15 @@
   (with-substitutes [#'state-2 dont-need-anyone]
     (deps/start #'state-3))
   (is (status) {#'state-1 :stopped #'state-2 :started #'state-3 :started}))
+
+(deftest start-with-overridden-dependency
+  (try
+    (def-someone)
+    (with-substitutes [#'state-2-a i-need-someone]
+      (deps/start #'state-2-a))
+    (is (status) {#'state-1 :started #'state-2 :started #'someone :started #'state-2-a :started})
+    (finally
+      (undef-someone))))
 
 (deftest stop-test
   (with-substitutes [#'state-2 dont-need-anyone]


### PR DESCRIPTION
Currently, transitive dependencies are being started in the order they
were loaded, not in dependency order. This can cause issues in
situations where new states which are needed for substitutes are
loaded much later than the original state that is being overridden to
depend on those new states.

An example of this is in a test environment where you may have
configuration overrides that you wouldn't define in your production
overrides that are loaded from dev-only code. Without this change, the
new test that was written would fail because the newly added dependency was
not loaded first.

I had to do a bit of a hack to remove a state defined by defstate-let me
know if there is a better way of doing this.