### PR TITLE
Breaking change: don't spawn child thread in with-session

### DIFF
--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -18,17 +18,36 @@
 
 ;;; The state protocol implementation.
 
-(defonce ^:private itl (InheritableThreadLocal.))
+(defn new-session
+  []
+  (gensym "mount-session-"))
+
+(defonce ^:private default-session (new-session))
+
+(defonce itl
+  (proxy [InheritableThreadLocal] []
+    (initialValue []
+      default-session)))
+
+(defonce ^:dynamic *session* default-session)
+
+(defn current-session
+  []
+  (or *session* (.get ^InheritableThreadLocal itl)))
+
+(defn- default-session?
+  []
+  (= (current-session) default-session))
 
 (defn- throw-started
   [name]
   (throw (Error. (format "state %s already started %s" name
-                         (if (.get ^InheritableThreadLocal itl) "in this session" "")))))
+                         (if (default-session?) "in this session" "")))))
 
 (defn- throw-unstarted
   [name]
   (throw (Error. (format "state %s not started %s" name
-                         (if (.get ^InheritableThreadLocal itl) "in this session" "")))))
+                         (if (default-session?) "in this session" "")))))
 
 (defn- throw-not-found
   [var]
@@ -39,29 +58,29 @@
   (start* [this]
     (if (= :stopped (status* this))
       (let [value (start-fn)]
-        (swap! sessions assoc (.get ^InheritableThreadLocal itl) (assoc (dissoc this :sessions) ::value value)))
+        (swap! sessions assoc (current-session) (assoc (dissoc this :sessions) ::value value)))
       (throw-started name)))
 
   (stop* [this]
     (let [value   (deref this)
-          stop-fn (get-in @sessions [(.get ^InheritableThreadLocal itl) :stop-fn])]
+          stop-fn (get-in @sessions [(current-session) :stop-fn])]
       (stop-fn value)
-      (swap! sessions dissoc (.get ^InheritableThreadLocal itl))))
+      (swap! sessions dissoc (current-session))))
 
   (status* [_]
-    (if (get @sessions (.get ^InheritableThreadLocal itl))
+    (if (get @sessions (current-session))
       :started
       :stopped))
 
   (properties [this]
     (-> this
-        (merge (get @sessions (.get ^InheritableThreadLocal itl)))
+        (merge (get @sessions (current-session)))
         (dissoc ::value :sessions)))
 
   IDeref
   (deref [this]
     (if (= :started (status* this))
-      (get-in @sessions [(.get ^InheritableThreadLocal itl) ::value])
+      (get-in @sessions [(current-session) ::value])
       (throw-unstarted name))))
 
 (prefer-method print-method Map IDeref)
@@ -190,25 +209,26 @@
        ~@body)))
 
 (defmacro with-session
-  "Creates a new thread, with a new system of states. All states are
-  initially in the stopped status in this thread, regardless of the
-  status in the thread that spawns this new session. This spawned
-  thread and its subthreads will automatically use the states that are
-  started within this thread or subthreads. Exiting the spawned thread
-  will automatically stop all states in this session.
+  "Creates a new thread, with a new system of states. All states are initially
+  in the stopped status in this thread, regardless of the status in the thread
+  that spawns this new session. This spawned thread and its subthreads, futures,
+  and agents will automatically use the states that are started within this
+  thread or subthreads. Exiting the spawned thread will automatically stop all
+  states in this session.
 
-  Returns a map with the spawned :thread and a :promise that will be
-  set to the result of the body or an exception."
+  Returns a map with the spawned :thread and a :promise that will be set to the
+  result of the body or an exception."
   [& body]
   `(let [p# (promise)]
      {:thread (doto (Thread. (fn []
-                               (.set ^InheritableThreadLocal @#'itl (Thread/currentThread))
-                               (try
-                                 (deliver p# (do ~@body))
-                                 (catch Throwable t#
-                                   (deliver p# t#)
-                                   (throw t#))
-                                 (finally
-                                   (stop)))))
+                               (binding [*session* (new-session)]
+                                 (.set ^InheritableThreadLocal itl *session*)
+                                 (try
+                                   (deliver p# (do ~@body))
+                                   (catch Throwable t#
+                                     (deliver p# t#)
+                                     (throw t#))
+                                   (finally
+                                     (stop))))))
                 (.start))
       :result p#}))

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -33,7 +33,7 @@
 
 (defn current-session
   []
-  (or *session* (.get ^InheritableThreadLocal itl)))
+  (or (.get ^InheritableThreadLocal itl) *session*))
 
 (defn- default-session?
   []

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -216,16 +216,18 @@
   Returns a map with the spawned :thread and a :promise that will be set to the
   result of the body or an exception."
   [& body]
-  `(let [p# (promise)]
-     {:thread (doto (Thread. (fn []
-                               (binding [*session* (new-session)]
-                                 (.set ^InheritableThreadLocal itl *session*)
-                                 (try
-                                   (deliver p# (do ~@body))
-                                   (catch Throwable t#
-                                     (deliver p# t#)
-                                     (throw t#))
-                                   (finally
-                                     (stop))))))
-                (.start))
+  `(let [p#        (promise)
+         bindings# (get-thread-bindings)
+         runnable# (fn []
+                    (with-bindings bindings#
+                      (binding [*session* (new-session)]
+                        (.set ^InheritableThreadLocal itl *session*)
+                        (try
+                          (deliver p# (do ~@body))
+                          (catch Throwable t#
+                            (deliver p# t#)
+                            (throw t#))
+                          (finally
+                            (stop))))))]
+     {:thread (doto (Thread. runnable#) (.start))
       :result p#}))

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -24,10 +24,7 @@
 
 (defonce ^:private default-session (new-session))
 
-(defonce itl
-  (proxy [InheritableThreadLocal] []
-    (initialValue []
-      default-session)))
+(defonce itl (InheritableThreadLocal.))
 
 (defonce ^:dynamic *session* default-session)
 

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -18,13 +18,13 @@
 
 ;;; The state protocol implementation.
 
-(defn new-session
+(defn- new-session
   []
   (gensym "mount-session-"))
 
 (defonce ^:private default-session (new-session))
 
-(defonce ^:dynamic *session* default-session)
+(defonce ^:private ^:dynamic *session* default-session)
 
 (defn- default-session?
   []

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -42,12 +42,12 @@
 (defn- throw-started
   [name]
   (throw (Error. (format "state %s already started %s" name
-                         (if (default-session?) "in this session" "")))))
+                         (if (default-session?) "" "in this session")))))
 
 (defn- throw-unstarted
   [name]
   (throw (Error. (format "state %s not started %s" name
-                         (if (default-session?) "in this session" "")))))
+                         (if (default-session?) "" "in this session")))))
 
 (defn- throw-not-found
   [var]

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -137,7 +137,9 @@
                        #'state-2   :started
                        #'state-2-a :stopped
                        #'state-2-b :stopped
-                       #'state-3   :stopped})))
+                       #'state-3   :stopped}))
+
+      (stop))
 
     (is (= (status) {#'state-1   :started
                      #'state-2   :stopped
@@ -172,7 +174,10 @@
                        #'state-2   :started
                        #'state-2-a :stopped
                        #'state-2-b :stopped
-                       #'state-3   :stopped})))
+                       #'state-3   :stopped}))
+
+      (stop))
+
     (is (= (status) {#'state-1   :started
                      #'state-2   :stopped
                      #'state-2-a :stopped
@@ -208,7 +213,10 @@
                        #'state-2   :started
                        #'state-2-a :stopped
                        #'state-2-b :stopped
-                       #'state-3   :stopped}))))
+                       #'state-3   :stopped}))
+
+      (stop)))
+
     (is (= (status) {#'state-1   :started
                      #'state-2   :stopped
                      #'state-2-a :stopped
@@ -245,7 +253,9 @@
                          #'state-2   :started
                          #'state-2-a :stopped
                          #'state-2-b :stopped
-                         #'state-3   :stopped}))))
+                         #'state-3   :stopped}))
+
+        (stop)))
 
     (is (= (status) {#'state-1   :started
                      #'state-2   :stopped
@@ -281,7 +291,9 @@
                          #'state-2   :started
                          #'state-2-a :stopped
                          #'state-2-b :stopped
-                         #'state-3   :stopped}))))
+                         #'state-3   :stopped}))
+
+        (stop)))
 
     (is (= (status) {#'state-1   :started
                      #'state-2   :stopped
@@ -320,7 +332,8 @@
                          #'state-2   :started
                          #'state-2-a :stopped
                          #'state-2-b :stopped
-                         #'state-3   :stopped})))))
+                         #'state-3   :stopped}))
+        (stop))))
 
     (is (= (status) {#'state-1   :started
                      #'state-2   :stopped

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -1,13 +1,11 @@
 (ns mount.lite-test
-  (:require [clojure.test :refer :all]
-            [mount.lite :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mount.lite :refer [*session* state status stop with-session with-session* with-substitutes start]]
             [mount.lite-test.test-state-1 :refer (state-1)]
             [mount.lite-test.test-state-2 :refer (state-2)]
-            [mount.lite-test.test-state-2-extra :as ts2e :refer (state-2-a state-2-b)]
+            [mount.lite-test.test-state-2-extra :as ts2e :refer [state-2-a state-2-b]]
             [mount.lite-test.test-state-3 :refer (state-3)])
   (:import [clojure.lang ExceptionInfo]))
-
-(def ^:dynamic *foo* "bar")
 
 ;;; Stop all states before and after every test.
 
@@ -16,53 +14,96 @@
 ;;; Tests
 
 (deftest test-start-stop
-  (is (= (start) [#'state-1 #'state-2 #'state-2-a #'state-2-b #'state-3]) "Start all states in correct order.")
-  (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :started #'state-2-b :started #'state-3 :started}))
-  (is (= @state-3 "state-1 + state-2 + state-3") "States can use othes states correctly.")
-  (is (= (stop) [#'state-3 #'state-2-b #'state-2-a #'state-2 #'state-1]) "Stop all states in correct order.")
-  (is (= (status) {#'state-1 :stopped #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
+  (is (= (start) [#'state-1 #'state-2 #'state-2-a #'state-2-b #'state-3])
+      "Start all states in correct order.")
+  (is (= (status)
+         {#'state-1   :started
+          #'state-2   :started
+          #'state-2-a :started
+          #'state-2-b :started
+          #'state-3   :started}))
+  (is (= @state-3 "state-1 + state-2 + state-3")
+      "States can use othes states correctly.")
+  (is (= (stop) [#'state-3 #'state-2-b #'state-2-a #'state-2 #'state-1])
+      "Stop all states in correct order.")
+  (is (= (status)
+         {#'state-1   :stopped
+          #'state-2   :stopped
+          #'state-2-a :stopped
+          #'state-2-b :stopped
+          #'state-3   :stopped})))
 
 (deftest test-up-to
   (is (= (start #'state-2) [#'state-1 #'state-2]) "Start state 1 and 2")
-  (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
+  (is (= (status)
+         {#'state-1   :started
+          #'state-2   :started
+          #'state-2-a :stopped
+          #'state-2-b :stopped
+          #'state-3   :stopped}))
   (is (= (start) [#'state-2-a #'state-2-b #'state-3]) "Start state 3")
-  (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :started #'state-2-b :started #'state-3 :started}))
-  (is (= (stop #'state-2) [#'state-3 #'state-2-b #'state-2-a #'state-2]) "Stop state 3 and 2")
-  (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
+  (is (= (status)
+         {#'state-1   :started
+          #'state-2   :started
+          #'state-2-a :started
+          #'state-2-b :started
+          #'state-3   :started}))
+  (is (= (stop #'state-2) [#'state-3 #'state-2-b #'state-2-a #'state-2])
+      "Stop state 3 and 2")
+  (is (= (status)
+         {#'state-1   :started
+          #'state-2   :stopped
+          #'state-2-a :stopped
+          #'state-2-b :stopped
+          #'state-3   :stopped})))
 
 (deftest test-substitute-state
-  (with-substitutes [#'state-1 (state :start "sub-1")] (start))
-  (is (= @state-3 "sub-1 + state-2 + state-3") "State 1 is substituted by anonymous state.")
+  (with-substitutes [#'state-1 (state :start "sub-1")]
+    (start))
+  (is (= @state-3 "sub-1 + state-2 + state-3")
+      "State 1 is substituted by anonymous state.")
   (stop)
   (start)
-  (is (= @state-3 "state-1 + state-2 + state-3") "State 1 is back to its original."))
+  (is (= @state-3 "state-1 + state-2 + state-3")
+      "State 1 is back to its original."))
 
 (deftest test-falsy-start
-  (is (state :start nil))
-  (is (state :start false)))
+  (is (state :start nil)) (is (state :start false)))
 
 (deftest test-substitute-map
-  (with-substitutes [#'state-2 {:start-fn (fn [] "sub-2")}] (start))
+  (with-substitutes [#'state-2 {:start-fn (fn [] "sub-2")}]
+    (start))
   (is (= @state-3 "sub-2 + state-3") "State 2 is substituted by map.")
   (stop)
   (start)
-  (is (= @state-3 "state-1 + state-2 + state-3") "State 2 is back to its original."))
+  (is (= @state-3 "state-1 + state-2 + state-3")
+      "State 2 is back to its original."))
 
 (deftest test-start-error
   (is (thrown? ExceptionInfo
-               (with-substitutes [#'state-1 (state :start (throw (ex-info "Boom!" {})))]
-                 (start)))))
+        (with-substitutes [#'state-1
+                           (state :start (throw (ex-info "Boom!" {})))]
+          (start)))))
 
 (deftest accessing-unstarted-throws-error
   (is (thrown? Error @state-1)))
 
 (deftest test-status
-  (is (= (status) {#'state-1 :stopped #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
+  (is (= (status)
+         {#'state-1   :stopped
+          #'state-2   :stopped
+          #'state-2-a :stopped
+          #'state-2-b :stopped
+          #'state-3   :stopped}))
   (start)
-  (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :started #'state-2-b :started #'state-3 :started})))
+  (is (= (status)
+         {#'state-1   :started
+          #'state-2   :started
+          #'state-2-a :started
+          #'state-2-b :started
+          #'state-3   :started})))
 
-(deftest extra-data
-  (is (= (:extra state-1) 'data)))
+(deftest extra-data (is (= (:extra state-1) 'data)))
 
 (deftest test-anonymous
   (let [stopped   (promise)
@@ -72,36 +113,225 @@
       (stop))
     (is (and (realized? stopped) (= 1 @stopped)) "this is bound")))
 
+(def ^:dynamic *foo* "bar")
+
 (deftest test-with-session
+  (testing "simple"
+    (start #'state-1)
+    (is (= (status)
+           {#'state-1   :started
+            #'state-2   :stopped
+            #'state-2-a :stopped
+            #'state-2-b :stopped
+            #'state-3   :stopped}))
+
+    (with-session
+      (is (= (status) {#'state-1   :stopped
+                       #'state-2   :stopped
+                       #'state-2-a :stopped
+                       #'state-2-b :stopped
+                       #'state-3   :stopped}))
+
+      (start #'state-2)
+      (is (= (status) {#'state-1   :started
+                       #'state-2   :started
+                       #'state-2-a :stopped
+                       #'state-2-b :stopped
+                       #'state-3   :stopped})))
+
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped})))
+
   (testing "with a nested future"
     (start #'state-1)
-    (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
-    @(:result
-      (with-session
-        (is (= (status) {#'state-1 :stopped #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
-        (start #'state-2)
-        @(future
-           (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
-        (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))))
-    (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
+    (is (= (status)
+           {#'state-1   :started
+            #'state-2   :stopped
+            #'state-2-a :stopped
+            #'state-2-b :stopped
+            #'state-3   :stopped}))
+
+    (with-session
+      (is (= (status) {#'state-1   :stopped
+                       #'state-2   :stopped
+                       #'state-2-a :stopped
+                       #'state-2-b :stopped
+                       #'state-3   :stopped}))
+
+      (start #'state-2)
+      @(future (is (= (status) {#'state-1   :started
+                                #'state-2   :started
+                                #'state-2-a :stopped
+                                #'state-2-b :stopped
+                                #'state-3   :stopped})))
+
+      (is (= (status) {#'state-1   :started
+                       #'state-2   :started
+                       #'state-2-a :stopped
+                       #'state-2-b :stopped
+                       #'state-3   :stopped})))
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped})))
 
   (testing "with a nested thread"
     (start #'state-1)
-    (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
-    @(:result
-      (with-session
-        (is (= (status) {#'state-1 :stopped #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
-        (start #'state-2)
-        (-> #(is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
-            (Thread.)
-            (.join))
-        (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
-    (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped}))
+    (with-session
+      (is (= (status) {#'state-1   :stopped
+                       #'state-2   :stopped
+                       #'state-2-a :stopped
+                       #'state-2-b :stopped
+                       #'state-3   :stopped}))
+
+      (start #'state-2)
+      (let [f (bound-fn []
+                (is (= (status) {#'state-1   :started
+                                 #'state-2   :started
+                                 #'state-2-a :stopped
+                                 #'state-2-b :stopped
+                                 #'state-3   :stopped})))]
+        (doto (Thread. ^Runnable f)
+          (.start)
+          (.join)))
+
+      (is (= (status) {#'state-1   :started
+                       #'state-2   :started
+                       #'state-2-a :stopped
+                       #'state-2-b :stopped
+                       #'state-3   :stopped}))))
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped})))
 
   (testing "maintaining bindings"
     (let [session *session*]
       (binding [*foo* "baz"]
-        @(:result
-          (with-session
+        (with-session
+          (is (not= *session* session))
+          (is (= *foo* "baz"))))))
+
+(deftest test-with-session*
+  (testing "simple"
+    (start #'state-1)
+    (is (= (status)
+           {#'state-1   :started
+            #'state-2   :stopped
+            #'state-2-a :stopped
+            #'state-2-b :stopped
+            #'state-3   :stopped}))
+
+    (with-session*
+      (fn []
+        (is (= (status) {#'state-1   :stopped
+                         #'state-2   :stopped
+                         #'state-2-a :stopped
+                         #'state-2-b :stopped
+                         #'state-3   :stopped}))
+
+        (start #'state-2)
+        (is (= (status) {#'state-1   :started
+                         #'state-2   :started
+                         #'state-2-a :stopped
+                         #'state-2-b :stopped
+                         #'state-3   :stopped}))))
+
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped})))
+
+  (testing "with a nested future"
+    (start #'state-1)
+    (is (= (status)
+           {#'state-1   :started
+            #'state-2   :stopped
+            #'state-2-a :stopped
+            #'state-2-b :stopped
+            #'state-3   :stopped}))
+
+    (with-session*
+      (fn []
+        (is (= (status) {#'state-1   :stopped
+                         #'state-2   :stopped
+                         #'state-2-a :stopped
+                         #'state-2-b :stopped
+                         #'state-3   :stopped}))
+
+        (start #'state-2)
+        @(future (is (= (status) {#'state-1   :started
+                                  #'state-2   :started
+                                  #'state-2-a :stopped
+                                  #'state-2-b :stopped
+                                  #'state-3   :stopped})))
+
+        (is (= (status) {#'state-1   :started
+                         #'state-2   :started
+                         #'state-2-a :stopped
+                         #'state-2-b :stopped
+                         #'state-3   :stopped}))))
+
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped})))
+
+  (testing "with a nested thread"
+    (start #'state-1)
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped}))
+
+    (with-session*
+      (fn []
+        (is (= (status) {#'state-1   :stopped
+                         #'state-2   :stopped
+                         #'state-2-a :stopped
+                         #'state-2-b :stopped
+                         #'state-3   :stopped}))
+
+        (start #'state-2)
+        (let [f (bound-fn []
+                  (is (= (status) {#'state-1   :started
+                                   #'state-2   :started
+                                   #'state-2-a :stopped
+                                   #'state-2-b :stopped
+                                   #'state-3   :stopped})))]
+          (doto (Thread. ^Runnable f)
+            (.start)
+            (.join)))
+
+        (is (= (status) {#'state-1   :started
+                         #'state-2   :started
+                         #'state-2-a :stopped
+                         #'state-2-b :stopped
+                         #'state-3   :stopped})))))
+
+    (is (= (status) {#'state-1   :started
+                     #'state-2   :stopped
+                     #'state-2-a :stopped
+                     #'state-2-b :stopped
+                     #'state-3   :stopped})))
+
+  (testing "maintaining bindings"
+    (let [session *session*]
+      (binding [*foo* "baz"]
+        (with-session*
+          (fn []
             (is (not= *session* session))
-            (is (= *foo* "baz"))))))))
+            (is (= *foo* "baz")))))))

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -7,6 +7,8 @@
             [mount.lite-test.test-state-3 :refer (state-3)])
   (:import [clojure.lang ExceptionInfo]))
 
+(def ^:dynamic *foo* "bar")
+
 ;;; Stop all states before and after every test.
 
 (use-fixtures :each (fn [f] (stop) (f) (stop)))
@@ -82,6 +84,7 @@
            (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
         (is (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))))
     (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
+
   (testing "with a nested thread"
     (start #'state-1)
     (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))
@@ -93,4 +96,12 @@
             (Thread.)
             (.join))
         (= (status) {#'state-1 :started #'state-2 :started #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
-    (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped}))))
+    (is (= (status) {#'state-1 :started #'state-2 :stopped #'state-2-a :stopped #'state-2-b :stopped #'state-3 :stopped})))
+
+  (testing "maintaining bindings"
+    (let [session *session*]
+      (binding [*foo* "baz"]
+        @(:result
+          (with-session
+            (is (not= *session* session))
+            (is (= *foo* "baz"))))))))

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -1,6 +1,6 @@
 (ns mount.lite-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [mount.lite :refer [*session* state status stop with-session with-session* with-substitutes start]]
+            [mount.lite :refer [state status stop with-session with-session* with-substitutes start]]
             [mount.lite-test.test-state-1 :refer (state-1)]
             [mount.lite-test.test-state-2 :refer (state-2)]
             [mount.lite-test.test-state-2-extra :as ts2e :refer [state-2-a state-2-b]]
@@ -113,8 +113,6 @@
       (stop))
     (is (and (realized? stopped) (= 1 @stopped)) "this is bound")))
 
-(def ^:dynamic *foo* "bar")
-
 (deftest test-with-session
   (testing "simple"
     (start #'state-1)
@@ -222,13 +220,6 @@
                      #'state-2-a :stopped
                      #'state-2-b :stopped
                      #'state-3   :stopped})))
-
-  (testing "maintaining bindings"
-    (let [session *session*]
-      (binding [*foo* "baz"]
-        (with-session
-          (is (not= *session* session))
-          (is (= *foo* "baz"))))))
 
 (deftest test-with-session*
   (testing "simple"
@@ -340,11 +331,3 @@
                      #'state-2-a :stopped
                      #'state-2-b :stopped
                      #'state-3   :stopped})))
-
-  (testing "maintaining bindings"
-    (let [session *session*]
-      (binding [*foo* "baz"]
-        (with-session*
-          (fn []
-            (is (not= *session* session))
-            (is (= *foo* "baz")))))))


### PR DESCRIPTION
This change simplifies with-session to just create a new binding context with a new session. This is a breaking change, and would require a major version update, which could understandably not be desirable. However, I found that the behavior exhibited by the current behavior to be surprising and at times unpredictable.

Clojure provides [`bound-fn`](https://clojuredocs.org/clojure.core/bound-fn) for precisely the use case that the `InheritableThreadLocal` is trying to handle. However, the `InheritableThreadLocal` doesn't play nicely with futures and agents, which is what #24 remediates. Overall, I think that _not_ spawning an asynchronous task in `with-session` would be more predictable, and pointing consumers at `bound-fn` for use with threads would be more in line with Clojure's binding design.

This change also introduces `with-session*`, which is a function version of `with-session`, which consumers can opt to use instead, much like Clojure provides [`bound-fn*`](https://clojuredocs.org/clojure.core/bound-fn*).

This is mostly here as an idea, since it is quite a major API change. It also removes the auto-stopping functionality, as inner states may have been started with one of the extensions, and a consumer may want more control over how the inner session is stopped.