### PR TITLE
 Changed `affected-vars` function to work with newer versions of `clojure.tools.namespace`.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
-  :profiles {:test {:dependencies [[org.clojure/tools.namespace "0.2.11"]]}}
+  :profiles {:test {:dependencies [[org.clojure/tools.namespace "0.2.11"]]}
+             :test-tools-namespace-0.3.x {:dependencies [^:replace [org.clojure/tools.namespace "0.3.1"]]}
+             :test-tools-namespace-1.x.x {:dependencies [^:replace [org.clojure/tools.namespace "1.1.0"]]}}
   :global-vars {*warn-on-reflection* true})

--- a/src/mount/extensions/refresh.clj
+++ b/src/mount/extensions/refresh.clj
@@ -2,8 +2,8 @@
   "An extension that offers helpers for working with the
   tools.namespace contrib library. Make sure you add the
   tools.namespace to the dependencies of your project yourself. This
-  extension has been tested with version 0.2.11 of the tools.namespace
-  library."
+  extension has been tested with versions 0.2.11, 0.3.1 and 1.1.0
+  of the tools.namespace library."
   {:clojure.tools.namespace.repl/load   false
    :clojure.tools.namespace.repl/unload false}
   (:require [mount.extensions.basic :as basic]

--- a/src/mount/extensions/refresh.clj
+++ b/src/mount/extensions/refresh.clj
@@ -15,8 +15,14 @@
 (def ^:private refresh-tracker
   (resolve 'clojure.tools.namespace.repl/refresh-tracker))
 
+(def ^:private refresh-dirs
+  (resolve 'clojure.tools.namespace.repl/refresh-dirs))
+
 (def ^:private scan
   (resolve 'clojure.tools.namespace.dir/scan))
+
+(def ^:private scan-dirs
+  (resolve 'clojure.tools.namespace.dir/scan-dirs))
 
 (def ^:private remove-disabled
   (resolve 'clojure.tools.namespace.repl/remove-disabled))
@@ -32,7 +38,19 @@
   clojure.tools.namespace.repl/refresh."
   []
   (if refresh-tracker
-    (let [nss (-> refresh-tracker deref scan remove-disabled :clojure.tools.namespace.track/unload set)]
+    (let [scan-fn (cond
+                    ;; `refresh-dirs` is set and `scan-dirs` is available.
+                    (and (seq refresh-dirs) scan-dirs)
+                    #(scan-dirs % refresh-dirs)
+
+                    ;; `refresh-dirs` is not set, but `scan-dirs` is available.
+                    scan-dirs
+                    #(scan-dirs %)
+
+                    ;; We are using 0.2.x version of `clojure.tools.namespace`.
+                    :else
+                    scan)
+          nss (-> refresh-tracker deref scan-fn remove-disabled :clojure.tools.namespace.track/unload set)]
       (keep (fn [kw]
               (when (nss (symbol (namespace kw)))
                 (utils/resolve-keyword kw)))

--- a/src/mount/extensions/refresh.clj
+++ b/src/mount/extensions/refresh.clj
@@ -40,8 +40,8 @@
   (if refresh-tracker
     (let [scan-fn (cond
                     ;; `refresh-dirs` is set and `scan-dirs` is available.
-                    (and (seq refresh-dirs) scan-dirs)
-                    #(scan-dirs % refresh-dirs)
+                    (and refresh-dirs (seq @refresh-dirs) scan-dirs)
+                    #(scan-dirs % @refresh-dirs)
 
                     ;; `refresh-dirs` is not set, but `scan-dirs` is available.
                     scan-dirs


### PR DESCRIPTION
- Works with `clojure.tools.namespace >= 0.3`.
- The function now uses `scan-dirs` instead of deprecated `scan`, whenever it can.
- Properly accounts for reloading if `refresh-dirs` is set with `clojure.tools.namespace.repl/set-refresh-dirs` function.
- Note that with newer versions of tools.namespace, setting `refresh-dirs` is mandatory in some cases like this: clojure-emacs/cider#2686