### PR TITLE
Add autostart extension

### DIFF
--- a/src/mount/extensions/autostart.clj
+++ b/src/mount/extensions/autostart.clj
@@ -1,4 +1,7 @@
 (ns mount.extensions.autostart
+  "This extension provides a `defstate` that auto-starts on first use.
+
+  Use `set-autostart-fn!` to configure which fn should be used to start the states."
   (:require [mount.lite :as mount])
   (:import [clojure.lang IDeref]
            [mount.lite IState]))

--- a/src/mount/extensions/autostart.clj
+++ b/src/mount/extensions/autostart.clj
@@ -1,0 +1,49 @@
+(ns mount.extensions.autostart
+  (:require [mount.lite :as mount])
+  (:import [clojure.lang IDeref]
+           [mount.lite IState]))
+
+(defonce
+  ^{:doc "The fn that will be called to automatically start any state
+    that has been deref'd but not started. If this fn is unsuccessful
+    in starting the state, the standard error handling will occur."}
+  autostart-fn mount/start)
+
+(defn set-autostart-fn!
+  "Configures `autostart-fn` use by `AutoStartState` during state deref."
+  [fn]
+  (alter-var-root #'autostart-fn (constantly fn)))
+
+(defrecord AutoStartState [var state]
+  IState
+  (start* [_]
+    (mount/start* state))
+
+  (stop* [_]
+    (mount/stop* state))
+
+  (status* [_]
+    (mount/status* state))
+
+  (properties [_]
+    (mount/properties state))
+
+  IDeref
+  (deref [_]
+    (if (= :started (mount/status* state))
+      @state
+      ;; synchronize access across thread boundaries just in case
+      ;; two threads want to access/start this state at the same time.
+      (locking var
+        (autostart-fn var)
+        @state))))
+
+(defmacro defstate
+  "Defines a state that should be auto-started on first deref.
+
+  See `mount.lite/defstate` for more information."
+  [name & args]
+  `(do
+     (mount/defstate ~name ~@args)
+     (alter-var-root (var ~name) (fn [state#] (->AutoStartState (var ~name) state#)))
+     (var ~name)))

--- a/src/mount/extensions/autostart.clj
+++ b/src/mount/extensions/autostart.clj
@@ -39,7 +39,7 @@
         @state))))
 
 (defmacro defstate
-  "Defines a state that should be auto-started on first deref.
+  "Defines a state that will be auto-started on first deref, including its dependencies.
 
   See `mount.lite/defstate` for more information."
   [name & args]

--- a/test/mount/extensions/autostart_test.clj
+++ b/test/mount/extensions/autostart_test.clj
@@ -27,8 +27,11 @@
     (mount/stop)
     (is (fully? :stopped)))
   (testing "with custom autostart-fn"
-    (sut/set-autostart-fn! deps/start)
-    (= 462 @third)
-    (is (fully? :started))
-    (mount/stop)
-    (is (fully? :stopped))))
+    (try
+      (sut/set-autostart-fn! deps/start)
+      (= 462 @third)
+      (is (fully? :started))
+      (mount/stop)
+      (is (fully? :stopped))
+      (finally
+        (sut/set-autostart-fn! mount/start)))))

--- a/test/mount/extensions/autostart_test.clj
+++ b/test/mount/extensions/autostart_test.clj
@@ -13,25 +13,26 @@
   :start 420)
 
 (sut/defstate third
-  :dependencies [#'first #'second]
-  :start (+ @first @second))
+  :dependencies [#'first]
+  :start (* 2 @first))
 
-(defn fully?
-  [state]
-  (= {#'first state #'second state #'third state} (mount/status)))
+(defn in-state?
+  [states]
+  (= (zipmap [#'first #'second #'third] states) (mount/status)))
 
 (deftest autostart-test
   (testing "with default autostart-fn"
-    (= 462 @third)
-    (is (fully? :started))
+    (= 84 @third)
+    (is (in-state? [:started :started :started]))
     (mount/stop)
-    (is (fully? :stopped)))
+    (is (in-state? [:stopped :stopped :stopped])))
   (testing "with custom autostart-fn"
     (try
       (sut/set-autostart-fn! deps/start)
-      (= 462 @third)
-      (is (fully? :started))
+      (= 84 @third)
+      (testing "explicit deps still only starts states in its deps tree"
+        (is (in-state? [:started :stopped :started])))
       (mount/stop)
-      (is (fully? :stopped))
+      (is (in-state? [:stopped :stopped :stopped]))
       (finally
         (sut/set-autostart-fn! mount/start)))))

--- a/test/mount/extensions/autostart_test.clj
+++ b/test/mount/extensions/autostart_test.clj
@@ -1,0 +1,34 @@
+(ns mount.extensions.autostart-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [mount.extensions.autostart :as sut]
+            [mount.extensions.explicit-deps :as deps]
+            [mount.lite :as mount]))
+
+(sut/defstate first
+  :dependencies []
+  :start 42)
+
+(sut/defstate second
+  :dependencies []
+  :start 420)
+
+(sut/defstate third
+  :dependencies [#'first #'second]
+  :start (+ @first @second))
+
+(defn fully?
+  [state]
+  (= {#'first state #'second state #'third state} (mount/status)))
+
+(deftest autostart-test
+  (testing "with default autostart-fn"
+    (= 462 @third)
+    (is (fully? :started))
+    (mount/stop)
+    (is (fully? :stopped)))
+  (testing "with custom autostart-fn"
+    (sut/set-autostart-fn! deps/start)
+    (= 462 @third)
+    (is (fully? :started))
+    (mount/stop)
+    (is (fully? :stopped))))


### PR DESCRIPTION
- Unlike other extensions, this one provides a new `defstate` macro that
  wraps `mount.lite/defstate`s in auto-start functionality.
- Synchronize startups across threads just in case derefs happen in
  multiple threads.
- `set-autostart-fn!` allows specifying of different start
  functionalities (i.e. standard `mount.lite/start` vs extension starts)