### PR TITLE
Add clj-kondo support for defstate macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 /mount-lite.iml
 .idea/
 /.lsp
+/.clj-kondo/*
+/!.clj-kondo/config.edn

--- a/resources/clj-kondo.exports/functionalbytes/mount-lite/config.edn
+++ b/resources/clj-kondo.exports/functionalbytes/mount-lite/config.edn
@@ -1,0 +1,3 @@
+{:hooks
+ {:analyze-call
+  {mount.lite/defstate hooks.lite/defstate-hook}}}

--- a/resources/clj-kondo.exports/functionalbytes/mount-lite/config.edn
+++ b/resources/clj-kondo.exports/functionalbytes/mount-lite/config.edn
@@ -1,3 +1,3 @@
-{:hooks
- {:analyze-call
-  {mount.lite/defstate hooks.lite/defstate-hook}}}
+{:hooks {:macroexpand {mount.lite/state                    hooks.lite/state
+                       mount.lite/defstate                 hooks.lite/defstate
+                       mount.extensions.autostart/defstate hooks.lite/defstate}}}

--- a/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
+++ b/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
@@ -1,0 +1,34 @@
+(ns hooks.lite
+  (:require
+    [clj-kondo.hooks-api
+     :as api
+     :refer [token-node list-node sexpr map-node keyword-node]]))
+
+(defn- map-node->map [nodes]
+  (zipmap (map sexpr (take-nth 2 nodes))
+          (take-nth 2 (rest nodes))))
+
+(defn defstate-hook [{:keys [node]}]
+  (let [[_ def-name & nodes] (:children node)
+        {:keys [start stop]} (map-node->map nodes)]
+    (when-not start
+      (throw (ex-info "missing :start expression" {})))
+    {:node
+     (list-node 
+       (list (token-node 'defonce)
+             def-name
+             (list-node
+               (list (token-node 'atom)
+                     (map-node
+                       (list (keyword-node :start)
+                             start
+                             (keyword-node :stop)
+                             (or stop (token-node nil))))))))}))
+
+(comment
+  (def node
+    (api/parse-string "(defstate db
+                        :start (db/start (get-in @config/config [:db :url]))
+                        :stop  (db/stop @db))"))
+  (sexpr node)
+  (sexpr (:node (defstate-hook {:node node}))))

--- a/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
+++ b/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
@@ -1,34 +1,25 @@
 (ns hooks.lite
-  (:require
-    [clj-kondo.hooks-api
-     :as api
-     :refer [token-node list-node sexpr map-node keyword-node]]))
+  (:require [clojure.string :as str]))
 
-(defn- map-node->map [nodes]
-  (zipmap (map sexpr (take-nth 2 nodes))
-          (take-nth 2 (rest nodes))))
+(defn- wrap-stop-fn [expr]
+  `(let [~'this nil] ~expr))
 
-(defn defstate-hook [{:keys [node]}]
-  (let [[_ def-name & nodes] (:children node)
-        {:keys [start stop]} (map-node->map nodes)]
-    (when-not start
+(defn- exprs-map [args]
+  (let [hmap    (apply hash-map args)]
+    (cond-> hmap
+      (some-> hmap :stop str (str/includes? "this"))
+      (update :stop wrap-stop-fn))))
+
+(defmacro defstate [name & args]
+  (let [args (cond->> args (string? (first args)) rest)
+        args (cond->> args (map? (first args)) rest)
+        hmap (exprs-map args)]
+    (when-not (contains? hmap :start)
       (throw (ex-info "missing :start expression" {})))
-    {:node
-     (list-node 
-       (list (token-node 'defonce)
-             def-name
-             (list-node
-               (list (token-node 'atom)
-                     (map-node
-                       (list (keyword-node :start)
-                             start
-                             (keyword-node :stop)
-                             (or stop (token-node nil))))))))}))
+    `(def ~name ~hmap)))
 
-(comment
-  (def node
-    (api/parse-string "(defstate db
-                        :start (db/start (get-in @config/config [:db :url]))
-                        :stop  (db/stop @db))"))
-  (sexpr node)
-  (sexpr (:node (defstate-hook {:node node}))))
+(defmacro state [& args]
+  (let [hmap (exprs-map args)]
+    (when-not (contains? hmap :start)
+      (throw (ex-info "missing :start expression" {})))
+    hmap))

--- a/src/mount/extensions/namespace_deps.clj
+++ b/src/mount/extensions/namespace_deps.clj
@@ -19,7 +19,7 @@
   (try
     (require 'clojure.tools.namespace.dir)
     (resolve 'clojure.tools.namespace.dir/scan-all)
-    (catch Exception e)))
+    (catch Exception _e)))
 
 (def ^:private dependency
   (try
@@ -27,7 +27,7 @@
     {:graph                   (resolve 'clojure.tools.namespace.dependency/graph)
      :transitive-dependencies (resolve 'clojure.tools.namespace.dependency/transitive-dependencies)
      :depend                  (resolve 'clojure.tools.namespace.dependency/depend)}
-    (catch Exception e)))
+    (catch Exception _e)))
 
 (defn- ns-graph->state-graph
   "Take two graphs with namespace-to-namespace `:dependencies` and

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -119,8 +119,7 @@
   Optionally one can define a :stop expression. Supports docstring and
   attribute map."
   [name & args]
-  (let [[name args] (utils/name-with-attrs name args)
-        current     (resolve name)]
+  (let [[name args] (utils/name-with-attrs name args)]
     `(do (defonce ~name (#'map->State {:sessions (atom nil)}))
          (let [local# (state :name ~(str name) ~@args)
                var#   (var ~name)

--- a/src/mount/utils.clj
+++ b/src/mount/utils.clj
@@ -5,7 +5,7 @@
   (let [[attrs args] (cond (and (string? arg1) (map? arg2)) [(assoc arg2 :doc arg1) argx]
                            (string? arg1)                   [{:doc arg1} (cons arg2 argx)]
                            (map? arg1)                      [arg1 (cons arg2 argx)]
-                           :otherwise                       [{} args])]
+                           :else                            [{} args])]
     [(with-meta name (merge (meta name) attrs)) args]))
 
 (defn find-index

--- a/test/mount/extensions/autostart_test.clj
+++ b/test/mount/extensions/autostart_test.clj
@@ -39,7 +39,7 @@
 
 (deftest autostart-test
   (testing "with default autostart-fn"
-    (= 84 @state-c)
+    (is (= 84 @state-c))
     (is-status {#'state-a :started #'state-b :started #'state-c :started})
     (mount/stop)
     (is-status {#'state-a :stopped #'state-b :stopped #'state-c :stopped}))
@@ -47,7 +47,7 @@
   (testing "with custom autostart-fn (explicit-deps)"
     (try
       (sut/set-autostart-fn! deps/start)
-      (= 84 @state-c)
+      (is (= 84 @state-c))
       (is-status {#'state-a :started #'state-b :stopped #'state-c :started})
       (mount/stop)
       (is-status {#'state-a :stopped #'state-b :stopped #'state-c :stopped})

--- a/test/mount/extensions/basic_test.clj
+++ b/test/mount/extensions/basic_test.clj
@@ -1,7 +1,7 @@
 (ns mount.extensions.basic-test
   (:require [clojure.test :refer (deftest is use-fixtures)]
             [mount.extensions.basic :as basic]
-            [mount.lite :refer :all]
+            [mount.lite :refer [start stop status]]
             [mount.lite-test.test-state-1 :refer (state-1)]
             [mount.lite-test.test-state-2 :refer (state-2)]
             [mount.lite-test.test-state-3 :refer (state-3)]))

--- a/test/mount/extensions/data_driven_test.clj
+++ b/test/mount/extensions/data_driven_test.clj
@@ -1,7 +1,7 @@
 (ns mount.extensions.data-driven-test
   (:require [clojure.test :refer (deftest is use-fixtures)]
             [mount.extensions.data-driven :as dd]
-            [mount.lite :refer :all]
+            [mount.lite :refer [state start stop status]]
             [mount.lite-test.test-state-1 :refer (state-1)]
             [mount.lite-test.test-state-2 :refer (state-2)]
             [mount.lite-test.test-state-3 :refer (state-3)]))

--- a/test/mount/extensions/explicit_deps_test.clj
+++ b/test/mount/extensions/explicit_deps_test.clj
@@ -4,7 +4,7 @@
             [mount.lite :refer (start state status stop with-substitutes)]
             [mount.lite-test.test-state-1 :as ts1 :refer (state-1)]
             [mount.lite-test.test-state-2 :as ts2 :refer (state-2)]
-            [mount.lite-test.test-state-2-extra :as ts2e :refer (state-2-a state-2-b)]
+            [mount.lite-test.test-state-2-extra :as ts2e]
             [mount.lite-test.test-state-3 :as ts3 :refer (state-3)]))
 
 ;;; Stop all states before and after every test.

--- a/test/mount/extensions/namespace_deps_test.clj
+++ b/test/mount/extensions/namespace_deps_test.clj
@@ -1,5 +1,5 @@
 (ns mount.extensions.namespace-deps-test
-  (:require [clojure.test :as test :refer (deftest is testing)]
+  (:require [clojure.test :as test :refer (deftest is)]
             [mount.extensions.namespace-deps :as sut]
             [mount.lite :as mount]
             [mount.lite-test.test-state-1 :as ts1 :refer (state-1)]

--- a/test/mount/lite_test.clj
+++ b/test/mount/lite_test.clj
@@ -1,6 +1,6 @@
 (ns mount.lite-test
-  (:require [clojure.test :refer :all]
-            [mount.lite :refer :all]
+  (:require [clojure.test :refer [deftest use-fixtures is]]
+            [mount.lite :refer [start stop status with-substitutes state]]
             [mount.lite-test.test-state-1 :refer (state-1)]
             [mount.lite-test.test-state-2 :refer (state-2)]
             [mount.lite-test.test-state-2-extra :as ts2e :refer (state-2-a state-2-b)]

--- a/test/mount/lite_test/test_state_1.clj
+++ b/test/mount/lite_test/test_state_1.clj
@@ -1,8 +1,7 @@
 (ns mount.lite-test.test-state-1
-  (:require [mount.lite :refer (defstate)])
-  (:import [java.util.concurrent TimeUnit]))
+  (:require [mount.lite :refer (defstate)]))
 
-(defstate state-1
+(defstate state-1 "docstring"
   :start "state-1"
   :stop @state-1
   :extra 'data

--- a/test/mount/lite_test/test_state_2.clj
+++ b/test/mount/lite_test/test_state_2.clj
@@ -2,6 +2,6 @@
   (:require [mount.lite :refer (defstate)]
             [mount.lite-test.test-state-1 :refer (state-1)]))
 
-(defstate state-2
+(defstate state-2 {:meta 'data}
   :start (str @state-1 " + state-2")
   :dependencies [#'state-1])

--- a/test/mount/lite_test/test_state_3.clj
+++ b/test/mount/lite_test/test_state_3.clj
@@ -1,3 +1,4 @@
+#_{:clj-kondo/ignore [:unused-namespace]}
 (ns mount.lite-test.test-state-3
   (:require [mount.lite :refer (defstate)]
             [mount.lite-test.test-state-2 :refer (state-2)]

--- a/test/mount/lite_test/test_state_3.clj
+++ b/test/mount/lite_test/test_state_3.clj
@@ -3,6 +3,6 @@
             [mount.lite-test.test-state-2 :refer (state-2)]
             [mount.lite-test.test-state-2-extra :as do-not-remove]))
 
-(defstate state-3
+(defstate state-3 "docstring" {:meta 'data}
   :start (str @state-2 " + state-3")
   :dependencies #{#'state-2})


### PR DESCRIPTION
Lib users will have hooks copied into their local .clj-kondo folder:
<img width="270" alt="image" src="https://user-images.githubusercontent.com/14236531/204099169-f7a44982-cec9-45de-8278-07771fbd6550.png">

Demo (`defstate` behaves like `defonce`, :start is required):
![defstate](https://user-images.githubusercontent.com/14236531/204110270-5b1628fe-a9a0-4a76-981b-4bd7cda43210.gif)

Clj-kondo lib's hooks examples: https://github.com/clj-kondo/clj-kondo/discussions/1528