### PR TITLE
Fix linting with new clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/functionalbytes/mount-lite"]}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,4 @@ pom.xml.asc
 .hg/
 /mount-lite.iml
 .idea/
-/.lsp
-/.clj-kondo/*
-/!.clj-kondo/config.edn
+.cache

--- a/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
+++ b/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
@@ -10,18 +10,16 @@
       (some-> hmap :stop str (str/includes? "this"))
       (update :stop wrap-stop-fn))))
 
-(defrecord IState [])
-
 (defmacro defstate [name & args]
   (let [args (cond->> args (string? (first args)) rest)
         args (cond->> args (map? (first args)) rest)
         hmap (exprs-map args)]
     (when-not (contains? hmap :start)
       (throw (ex-info "missing :start expression" {})))
-    `(def ~name ~(map->IState hmap))))
+    `(def ~name (mount.lite/map->State ~hmap))))
 
 (defmacro state [& args]
   (let [hmap (exprs-map args)]
     (when-not (contains? hmap :start)
       (throw (ex-info "missing :start expression" {})))
-    (map->IState hmap)))
+    `(mount.lite/map->State ~hmap)))

--- a/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
+++ b/resources/clj-kondo.exports/functionalbytes/mount-lite/hooks/lite.clj
@@ -10,16 +10,18 @@
       (some-> hmap :stop str (str/includes? "this"))
       (update :stop wrap-stop-fn))))
 
+(defrecord IState [])
+
 (defmacro defstate [name & args]
   (let [args (cond->> args (string? (first args)) rest)
         args (cond->> args (map? (first args)) rest)
         hmap (exprs-map args)]
     (when-not (contains? hmap :start)
       (throw (ex-info "missing :start expression" {})))
-    `(def ~name ~hmap)))
+    `(def ~name ~(map->IState hmap))))
 
 (defmacro state [& args]
   (let [hmap (exprs-map args)]
     (when-not (contains? hmap :start)
       (throw (ex-info "missing :start expression" {})))
-    hmap))
+    (map->IState hmap)))

--- a/src/mount/lite.clj
+++ b/src/mount/lite.clj
@@ -211,3 +211,9 @@
                                    (stop)))))
                 (.start))
       :result p#}))
+
+(comment
+  (def x 1)
+  (defstate foo :start (fn [] x))
+  @foo
+  )


### PR DESCRIPTION
The problem was that `@state` would give a type mismatch since maps don't implement `IDeref`.