### PR TITLE
Fix redefining autostarting state

### DIFF
--- a/src/mount/extensions/autostart.clj
+++ b/src/mount/extensions/autostart.clj
@@ -47,6 +47,8 @@
   See `mount.lite/defstate` for more information."
   [name & args]
   `(do
+     (when-let [existing# (resolve '~name)]
+       (alter-var-root existing# (fn [state#] (cond-> state# (instance? AutoStartState state#) :state))))
      (mount/defstate ~name ~@args)
      (alter-var-root (var ~name) (fn [state#] (->AutoStartState (var ~name) state#)))
      (var ~name)))

--- a/test/mount/extensions/autostart_test.clj
+++ b/test/mount/extensions/autostart_test.clj
@@ -52,4 +52,12 @@
       (mount/stop)
       (is-status {#'state-a :stopped #'state-b :stopped #'state-c :stopped})
       (finally
-        (sut/set-autostart-fn! mount/start)))))
+        (sut/set-autostart-fn! mount/start))))
+
+  (testing "redefining state"
+    (in-ns 'mount.extensions.autostart-test)
+    (is (= 42 @state-a))
+    (sut/defstate state-a :start 4242)
+    (is (= 42 @state-a))
+    (mount/stop)
+    (is (= 4242 @state-a))))


### PR DESCRIPTION
The autostart extension works by wrapping a State record by the AutoStartState record, by updating the var created by the standard defstate. Since that var is a defonce, the autostart extension wrapped itself on redefining a state.

The fix checks whether the var already exists and is an AutoStartState. If so, it first unwraps it.

Fixes #32 